### PR TITLE
Proof of concept for a JsonCell type for Bobtail.

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,238 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define('bobtail-deep-cell', ['exports', 'underscore', 'bobtail-rx', 'lodash.get', 'lodash.set', 'jsondiffpatch'], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require('underscore'), require('bobtail-rx'), require('lodash.get'), require('lodash.set'), require('jsondiffpatch'));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global._, global.rx, global.lodashGet, global.lodashSet, global.jsondiffpatch);
+    global.bobtailDeepCell = mod.exports;
+  }
+})(this, function (exports, _underscore, _bobtailRx, _lodash, _lodash3, _jsondiffpatch) {
+  'use strict';
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.update = exports.deepCell = exports.DeepCell = exports.HAS = exports.GET = exports.DATA = exports.ONCHANGE = undefined;
+
+  var _underscore2 = _interopRequireDefault(_underscore);
+
+  var _bobtailRx2 = _interopRequireDefault(_bobtailRx);
+
+  var _lodash2 = _interopRequireDefault(_lodash);
+
+  var _lodash4 = _interopRequireDefault(_lodash3);
+
+  var _jsondiffpatch2 = _interopRequireDefault(_jsondiffpatch);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+    }
+
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
+    });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+  }
+
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    } else {
+      obj[key] = value;
+    }
+
+    return obj;
+  }
+
+  var jsondiffpatch = _jsondiffpatch2.default.create({
+    //  objectHash: (obj) -> obj.name or obj.id or obj._id
+    cloneDiffValues: true
+  });
+
+  var recorder = _bobtailRx2.default._recorder;
+  var ONCHANGE = exports.ONCHANGE = Symbol("onChange");
+  var DATA = exports.DATA = Symbol("data");
+  var GET = exports.GET = Symbol("get");
+  var HAS = exports.HAS = Symbol("has");
+
+  var patchHas = function patchHas(obj, path) {
+    //  debugger
+    var diffArray = false;
+    var h = function h(obj, path) {
+      if (_underscore2.default.isArray(obj) && !diffArray) {
+        diffArray = true;
+        obj = obj[0];
+      }
+      if (_underscore2.default.isObject(obj)) {
+        if (!(path[0] in obj)) {
+          return false;
+        } else if (path.length === 1) {
+          return true;
+        }
+        return h(obj[path[0]], path.slice(1));
+      }
+      return false;
+    };
+    return h(obj, path);
+  };
+
+  var prefixDiff = function prefixDiff(basePath, diff) {
+    if (!basePath.length) {
+      return diff;
+    }
+    var x = {};
+    (0, _lodash4.default)(x, basePath, diff);
+    return x;
+  };
+
+  var conf = function conf(baseObj, basePath, onChange, parent) {
+    var getPath = function getPath() {
+      for (var _len = arguments.length, props = Array(_len), _key = 0; _key < _len; _key++) {
+        props[_key] = arguments[_key];
+      }
+
+      return basePath.concat(props);
+    };
+
+    return {
+      deleteProperty: function deleteProperty(obj, prop) {
+        var path = getPath(prop);
+        var old = obj[prop];
+        onChange.pub(prefixDiff(path, [old, 0, 0]));
+        return delete obj[prop];
+      },
+      set: function set(obj, prop, val) {
+        return recorder.mutating(function () {
+          var old = obj[prop];
+          var diff = jsondiffpatch.diff(_defineProperty({}, prop, old), _defineProperty({}, prop, val));
+          if (diff) {
+            jsondiffpatch.patch(obj, diff);
+            var x = prefixDiff(basePath, diff);
+            onChange.pub(x);
+          }
+          return true;
+        });
+      },
+      get: function get(obj, prop) {
+        if (prop === ONCHANGE) {
+          return onChange;
+        }
+        if (['constructor', '__proto__'].includes(prop)) {
+          return val;
+        }
+        var val = obj[prop];
+        if (prop === GET || prop === 'getRx' && !(prop in obj)) {
+          return function (key) {
+            var path = getPath(prop, key);
+            recorder.sub(onChange, function (patch) {
+              return patchHas(patch, path);
+            });
+            return new Proxy(val[key], conf(baseObj, path, onChange, obj));
+          };
+        }
+        if (prop === HAS || prop === 'getRx' && !(prop in obj)) {
+          return function (key) {
+            var path = getPath(prop, key);
+            recorder.sub(onChange, function (patch) {
+              return patchHas(patch, path);
+            });
+            return prop in obj;
+          };
+        }
+        if (_underscore2.default.isObject(val)) {
+          return new Proxy(val, conf(baseObj, getPath(prop), onChange, obj));
+        }
+        return val;
+      },
+      ownKeys: function ownKeys(obj) {
+        recorder.sub(onChange, function (patch) {
+          var delta = (0, _lodash2.default)(patch, basePath);
+          if (!delta) {
+            return false;
+          }
+          // if we added or removed fields on this object
+          if (_underscore2.default.isArray(delta && delta.length !== 2)) {
+            return true;
+          }
+          // true if we added or removed elements to this array, else false
+          return delta._t === 'a' && _underscore2.default.chain(delta).omit('_t').values().value().some(function (v) {
+            return _underscore2.default.isArray(v) && (v.length === 1 || v[1] === 0 && v[2] === 0);
+          });
+        });
+
+        return Reflect.ownKeys(obj);
+      },
+      apply: function apply(target, thisArg, argumentsList) {
+        return target.apply(thisArg || parent, argumentsList);
+      }
+    };
+  };
+
+  var DeepCell = exports.DeepCell = function (_rx$ObsBase) {
+    _inherits(DeepCell, _rx$ObsBase);
+
+    function DeepCell(_base) {
+      _classCallCheck(this, DeepCell);
+
+      var _this = _possibleConstructorReturn(this, (DeepCell.__proto__ || Object.getPrototypeOf(DeepCell)).call(this));
+
+      _this._base = _base != null ? _base : {};
+      if (!_underscore2.default.isObject(_this._base)) {
+        throw "DeepCell must take an object";
+      }
+
+      _this[ONCHANGE] = _this._mkEv(function () {
+        return jsondiffpatch.diff({}, _this._base);
+      });
+      _this[DATA] = new Proxy(_this._base, conf(_this._base, [], _this[ONCHANGE]));
+      return _this;
+    }
+
+    return DeepCell;
+  }(_bobtailRx2.default.ObsBase);
+
+  var deepCell = exports.deepCell = function deepCell(_base) {
+    return new DeepCell(_base)[DATA];
+  };
+  var update = exports.update = function update(cell, newVal) {
+    var diff = jsondiffpatch.diff(cell, newVal);
+    jsondiffpatch.patch(cell, diff);
+    return true;
+  };
+});
+

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "bobtail-deep-cell",
+  "name": "bobtail-json-cell",
   "version": "0.1.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "homepage": "https://github.com/bobtail-dev/bobtail-deep-cell#readme",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run babel && npm run minify",
-    "babel": "babel src/main.js > dist/main.js",
+    "babel": "babel src/main.js --out-file dist/main.js --source-maps",
     "clean": "rm -rf dist && mkdir dist",
     "minify": "uglifyjs -mc --source-map --screw-ie8 -o dist/main.min.js dist/main.js",
     "typescript": "",
@@ -30,13 +30,23 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
+    "bobtail-rx": "^2.1.1",
     "jasmine": "^2.6.0",
     "jasmine-core": "^2.5.2",
     "jquery": "^3.2.1",
+    "nevernull": "^1.3.0",
     "typescript": "^2.1.6",
     "uglify-es": "^3.0.23"
   },
   "dependencies": {
+    "jsondiffpatch": "^0.2.4",
+    "lodash.get": "^4.4.2",
+    "lodash.hasin": "^4.5.2",
+    "lodash.set": "^4.3.2",
+    "lodash.unset": "^4.5.2",
     "underscore": "^1.8.3"
+  },
+  "peerDependencies": {
+    "bobtail-rx": "^2.1.1"
   }
 }

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -1,4 +1,128 @@
+import nn from 'nevernull';
+import _ from 'underscore';
+import * as rx from 'bobtail-rx';
+import * as jsonRx from '../src/main.js';
+let {snap, bind} = rx;
+let {logReturn, patchHas, JsonCell, jsonCell} = jsonRx;
+import deepGet from 'lodash.get';
+
 jasmine.CATCH_EXCEPTIONS = false;
 
-describe('Tests', () => it('should run', function() {expect(1 + 1).toBe(2)}));
+describe('get', () => {
+  it('should react to deletions, changes and additions', () => {
+    let foo = jsonCell({
+      a: {b: {c: 1, d: 2}},
+      e: 3,
+      f: {x: {y: 42, z: ['e', 'b', 'r', 'a']}}
+    });
+    let zebra = bind(() => {
+      let suffix = deepGet(foo, 'f.x.z');
+      return suffix ? 'z' + suffix.join('') : undefined;
+    });
+    expect(zebra.raw()).toBe('zebra');
+    foo.f.x.z.push('i');
+    expect(zebra.raw()).toBe('zebrai');
+    foo.f.x = {z: ['l', 'i', 'o', 'n']};
+    expect(zebra.raw()).toBe('zlion');
+    delete foo.f.x;
+    expect(zebra.raw()).toBeUndefined();
+    snap(() => foo.f.x = {z: ['a', 'b', 'c']});
+    expect(zebra.raw()).toBe('zabc');
+  });
+});
 
+describe('has', () => {
+  let foo, a, z, q;
+  beforeEach(() => {
+    foo = jsonCell({
+      a: {b: {c: 1, d: 2}},
+      e: 3,
+      f: {x: {y: 42, z: ['e', 'b', 'r', 'a']}}
+    });
+    a = bind(() => 'a' in foo);
+    z = bind(() => 'z' in (nn(foo).f.x() || {}));
+    q = bind(() => 'q' in (nn(foo).f.x() || {}));
+  });
+  it('should not react to changes', () => {
+    expect(a.raw()).toBe(true);
+    expect(z.raw()).toBe(true);
+    expect(q.raw()).toBe(false);
+    foo.a = 42;
+    expect(a.raw()).toBe(true);
+    expect(z.raw()).toBe(true);
+    expect(q.raw()).toBe(false);
+    foo.f = {x: {z: 1}};
+    expect(a.raw()).toBe(true);
+    expect(z.raw()).toBe(true);
+    expect(q.raw()).toBe(false);
+    foo.f.x.y = 1;
+    expect(a.raw()).toBe(true);
+    expect(z.raw()).toBe(true);
+    expect(q.raw()).toBe(false);
+  });
+  it('should react to additions and deletions', () => {
+    expect(a.raw()).toBe(true);
+    expect(z.raw()).toBe(true);
+    expect(q.raw()).toBe(false);
+    delete foo.a;
+    expect(a.raw()).toBe(false);
+    expect(z.raw()).toBe(true);
+    expect(q.raw()).toBe(false);
+    delete foo.f;
+    expect(a.raw()).toBe(false);
+    expect(z.raw()).toBe(false);
+    expect(q.raw()).toBe(false);
+  });
+});
+
+let testArray = (obj, path) => {
+  let mkArr = () => path ? deepGet(obj, path) : obj;
+  let cell = bind(() => mkArr());
+  let length = bind(() => mkArr() && mkArr().length);
+  let arr = mkArr();
+  expect(cell.raw()).toEqual([0, 1, 2, 3, 4]);
+  expect(length.raw()).toBe(5);
+  arr.push(5);
+  expect(cell.raw()).toEqual([0, 1, 2, 3, 4, 5]);
+  expect(length.raw()).toBe(6);
+  arr[0] = 42;
+  expect(cell.raw()).toEqual([42, 1, 2, 3, 4, 5]);
+  expect(length.raw()).toBe(6);
+  arr.shift();
+  expect(cell.raw()).toEqual([1, 2, 3, 4, 5]);
+  expect(length.raw()).toBe(5);
+  arr.splice(1, 3);
+  expect(cell.raw()).toEqual([1, 5]);
+  expect(length.raw()).toBe(2);
+  return {cell, length};
+};
+
+describe('array', () => {
+  it("should support all array operations on raw arrays", () => {
+    let arr = jsonCell([0, 1, 2, 3, 4]);
+    testArray(arr);
+  });
+  it("should support all array operations on nested arrays", () => {
+    let arr = jsonCell({x: [0, 1, 2, 3, 4]});
+    let {cell, length} = testArray(arr, 'x');
+    delete arr.x;
+    expect(cell.raw()).toBeUndefined();
+    expect(length.raw()).toBeUndefined();
+  });
+});
+
+describe('onUnsafeMutation', () => {
+  it('should fire if a value is set from within a bind context', () => {
+    let foobar = new JsonCell({a: 1, b: 2, c: 'lala'});
+    let spy = jasmine.createSpy('spy');
+    foobar.onUnsafeMutation.pub = spy;
+    expect(spy.calls.count()).toBe(0);
+    bind(() => {
+      foobar.data.b = foobar.data.c + 'la';
+      return foobar.data.c;
+    });
+    expect(spy.calls.count()).toBe(1);
+    foobar.data.c = 'lalala';
+    expect(spy.calls.count()).toBe(2);
+  })
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,204 @@
+import nn from 'nevernull';
+import _ from 'underscore';
+import * as rx from 'bobtail-rx';
+import deepGet from 'lodash.get';
+import deepSet from 'lodash.set';
+import deepHas from 'lodash.hasin';
+
+import patchFactory from 'jsondiffpatch';
+
+let jsondiffpatch = patchFactory.create({
+//  objectHash: (obj) -> obj.name or obj.id or obj._id
+  cloneDiffValues: true
+});
+
+let recorder = rx._recorder;
+
+export let patchHas = function(patch, path, diffArray=false) {
+  if(_.isString(path)) {
+    return patchHas(patch, path.split('.'));  // potentially ambiguous with empty or dot-containing property names
+  }
+  if(!path.length) {return true;}
+  if (_.isArray(patch) && !diffArray) {
+    diffArray = true;
+    patch = patch[0];
+  }
+
+  let [first, ...rest] = path;
+
+  if (_.isObject(patch)) {
+    if (!diffArray && patch._t === 'a') {
+      let under = `${first}`;
+      if(under in patch) {
+        return patchHas(patch[under], rest, diffArray);
+      }
+      else if(first in patch) {
+        return patchHas(patch[first], rest, diffArray);
+      }
+      return false;
+    }
+    if (!(first in patch)) {
+      return false;
+    } else if (path.length === 1) {
+      return true;
+    }
+    return patchHas(patch[first], rest, diffArray);
+  }
+  return false;
+};
+
+let prefixDiff = function(basePath, diff) {
+  if (!basePath.length) { return diff; }
+  let x = {};
+  deepSet(x, basePath, diff);
+  return x;
+};
+
+export function logReturn(x) {
+  console.info(x);
+  return x;
+}
+
+let lengthChange = patchVal =>
+  _.isArray(patchVal) && ((patchVal.length === 1) || (patchVal[1] === 0 && patchVal[2] === 0));
+
+export let UPDATE = Symbol('update');
+
+export class JsonCell extends rx.ObsBase {
+  constructor(_base) {
+    super();
+    this._base = _base != null ? _base: {};
+    this.onChange = this._mkEv(() => jsondiffpatch.diff({}, this._base));
+    this.onUnsafeMutation = this._mkEv(() => {});
+    this._data = new Proxy(this._base, this.conf([], null));
+  }
+
+  get data() {return this._data;}
+  set data(val) {this.update(val);}
+
+  static stDel(obj, prop) {return delete obj[prop];}
+  del(obj, prop) {return this.__proto__.constructor.stDel(obj, prop);}
+  static stSet(obj, prop, val) {return obj[prop] = val;}
+  set(obj, prop) {return this.__proto__.constructor.stSet(obj, prop);}
+
+  update (newVal) {
+    let diff = jsondiffpatch.diff(this.data, newVal);
+    jsondiffpatch.patch(this.data, diff);
+    return true;
+  }
+
+  conf(basePath) {
+    let getPath = (...props) => basePath.concat(props);
+
+    return {
+      deleteProperty: (obj, prop) => {
+        let path = getPath(prop);
+        if (recorder.stack.length > 0) {
+          // the default mutation warning is nowhere near dire enough. mutating nested objects within a
+          // bind is extremely likely to lead to infinite loops.
+          console.warn(
+            `Warning: deleting nested element at ${path.join('.')} from within a bind context. Affected object:`, obj
+          );
+          this.onUnsafeMutation.pub({op: 'delete', path, obj, prop, base: this._base})
+        }
+        recorder.mutating(() => {
+          let old = obj[prop];
+          let diff = prefixDiff(basePath, [{[prop]: old}, 0, 0]);
+          if(prop in obj) {
+            this.del(obj, prop);
+            this.onChange.pub(diff);
+          }
+        });
+        return true;
+      },
+      set: (obj, prop, val) => {
+        let path = getPath(prop);
+        if (recorder.stack.length > 0) {
+          // the default mutation warning is nowhere near dire enough. mutating nested objects within a
+          // bind is extremely likely to lead to infinite loops.
+          console.warn(
+            `Warning: updating nested element at ${path.join('.')} from within a bind context. Affected object:`, obj
+          );
+          this.onUnsafeMutation.pub({op: 'set', path, obj, prop, val, base: this._base});
+        }
+        recorder.mutating(() => {
+          let old = rx.snap(() => obj[prop]);
+          let diff = jsondiffpatch.diff({[prop]: old}, {[prop]: val});
+          if (diff) {
+            rx.snap(() => jsondiffpatch.patch(obj, diff));
+            this.onChange.pub(prefixDiff(basePath, diff));
+          }
+        });
+        return true;
+      },
+      get: (obj, prop) => {
+        let val = obj[prop];
+        if (prop === '__proto__' || _.isFunction(val)) {
+          return val;
+        }
+        if (prop === UPDATE || (prop === 'updateRxb' && !('updateRxb' in obj))) {
+          return other => jsondiffpatch.patch(obj, jsondiffpatch.diff(obj, other));
+        }
+        let path = getPath(prop);
+        if (prop === 'length' && _.isArray(obj)) {
+          let oldVal = obj.length;
+          recorder.sub(this.onChange, () => {
+            let newVal = deepGet(this._base, path);
+            if(newVal !== oldVal){
+              oldVal = newVal;
+              return true;
+            }
+            return false;
+          });
+        }
+        else {
+          recorder.sub(this.onChange, patch => patchHas(patch, path));
+        }
+        // return new Proxy(deepGet(this._base, path), this.conf(path, obj));
+        if (_.isObject(val)) {
+          return new Proxy(val, this.conf(getPath(prop), obj));
+        }
+        return val;
+      },
+      has: (obj, prop) => {
+        let path = getPath(prop);
+        let had = prop in obj;
+        recorder.sub(this.onChange, patch => {
+          let has = deepHas(this._base, path);
+          if(had !== has) {
+            had = has;
+            return true;
+          }
+          return false;
+        });
+        return had;
+      },
+      ownKeys: obj => {
+        recorder.sub(this.onChange, patch => {
+          let delta = deepGet(patch, basePath);
+          if (!delta) {
+            return false;
+          }
+          // if we added or removed fields on this object
+          if (_.isArray(delta && (delta.length !== 2))) {
+            return true;
+          }
+          // true if we added or removed elements to this array, else false
+          return (delta._t === 'a') && _.chain(delta).omit('_t').values().value().some(
+
+          );
+        });
+
+        return Reflect.ownKeys(obj);
+      }
+    }
+  }
+}
+
+export let jsonCell = _base => new JsonCell(_base).data;
+
+export let update = (cell, newVal) => {
+  let diff = jsondiffpatch.diff(cell, newVal);
+  jsondiffpatch.patch(cell, diff);
+  return true;
+};


### PR DESCRIPTION
Essentially the idea is to have a cell type that mimics
regular JSON objects. No need to call .get() or .set();
ES2015's Proxies allow regular object setting and getting
to trigger events and record dependencies.

Currently, binding and refreshing are very inefficient.
e.g., bind -> w.x.y.z will check to see if it needs to
refresh on any changes to any of the keys in that
change--though of course it usually will not.

Finally, the API is still very much in flux. Numerous
support methods and functions, e.g. for casting, still need
to be added.